### PR TITLE
add support for php 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Compatible with Magento Open Source and Adobe Commerce.
 
 # Change Log
 
+### Unreleased
+- Add PHP 8.4 compatibility
+
 ### Version : V1.0.27
 - Updated PHP version constraint, added PHP 8.3 compatibility
 - Compatible with **Magento 2.4.7**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "scientiamobile/module-magento2-image-cdn-imageengine",
   "description": "Image CDN Extension for Magento2 by ImageEngine",
   "require": {
-    "php": "~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0|~8.2.0|~8.3.0"
+    "php": "~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0|~8.2.0|~8.3.0|~8.4.0"
   },
   "version": "1.0.27",
   "license": "MIT",


### PR DESCRIPTION
PHP 8.3/8.4 compatibility has been checked with rector:
```
rector -c rector.php process vendor/scientiamobile/module-magento2-image-cdn-imageengine
```

**rector.php**:
```php
<?php

declare(strict_types=1);
// rector 1.0 config
use Rector\Config\RectorConfig;
use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
use Rector\Set\ValueObject\SetList;
use Rector\ValueObject\PhpVersion;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->phpVersion(PhpVersion::PHP_84);
    $rectorConfig->disableParallel();
    $rectorConfig->import(SetList::PHP_83);
    $rectorConfig->import(SetList::PHP_84);
    $rectorConfig->skip([AddOverrideAttributeToOverriddenMethodsRector::class]);
};
```
There were no issues found, so it only requires the metadata updates